### PR TITLE
Refactored compiler API and logic

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/compilers/native.py
+++ b/tabular/src/autogluon/tabular/models/rf/compilers/native.py
@@ -27,6 +27,7 @@ class AbstractNativeCompiler:
             The compiler would optimize the model to perform best with the given input type.
         """
         AbstractNativeCompiler.save(model, path)
+        return model
 
     @staticmethod
     def save(model, path: str):
@@ -36,7 +37,6 @@ class AbstractNativeCompiler:
 
     @staticmethod
     def load(path: str):
-        pkl = None
         with open(path + 'model_native.pkl', 'rb') as fp:
             pkl = fp.read()
         return pickle.loads(pkl)

--- a/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
+++ b/tabular/src/autogluon/tabular/models/rf/compilers/onnx.py
@@ -98,8 +98,9 @@ class RFOnnxCompiler:
 
         # Convert the model to onnx
         onnx_model = convert_sklearn(model, initial_types=initial_type, options=options)
-        predictor =  RFOnnxPredictor(model=onnx_model)
+        predictor = RFOnnxPredictor(model=onnx_model)
         RFOnnxCompiler.save(onnx_model, path)
+        return predictor
 
     @staticmethod
     def save(model, path: str) -> str:

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -369,22 +369,3 @@ class RFModel(AbstractModel):
 
     def _default_compiler(self):
         return RFNativeCompiler
-
-    def save(self, path: str = None, verbose=True) -> str:
-        _model = self.model
-        if self.model is not None:
-            self._compiler = self._get_compiler()
-            self._is_model_saved = True
-            self._compiler.save(self.model, self.path)
-            if self._compiler is not None:
-                self.model = None  # Don't save model in pkl
-        path = super().save(path=path, verbose=verbose)
-        self.model = _model
-        return path
-
-    @classmethod
-    def load(cls, path: str, reset_paths=True, verbose=True):
-        model = super().load(path=path, reset_paths=reset_paths, verbose=verbose)
-        if model._is_model_saved:
-            model.model = model._compiler.load(path=path)
-        return model

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1950,27 +1950,55 @@ class TabularPredictor:
             fi_df[low_str] = pd.Series(ci_low_dict)
         return fi_df
 
-    def compile_models(self, models='best', with_ancestors=True, compiler_configs=None):
+    def compile_models(self, models='best', with_ancestors=True, compiler_configs="auto"):
         """
         Compile models for accelerated prediction.
         This can be helpful to reduce prediction latency and improve throughput.
 
-        Note that this is currently an experimental feature, the supported alternative compiler can be ['native', 'onnx'].
+        Note that this is currently an experimental feature, the supported compilers can be ['native', 'onnx'].
+
+        In order to compile with a specific compiler, that compiler must be installed in the Python environment.
 
         Parameters
         ----------
-        compiler_configs : dict, default = {}
-            compiler : str, default = 'native'
-                The compiler that is used for model compilation.
-            batch_size : int, default = None
-                The batch size that is optimized for model prediction.
-                By default, the batch size is None. This means the compiler would try to leverage dynamic shape for prediction.
-                Using batch_size=1 would be more suitable for online prediction, which expects a result from one data point.
-                However, it can be slow for batch processing, because of the overhead of multiple kernel execution.
-                Increasing batch size to a number that is larger than 1 would help increase the prediction throughput.
-                This comes with an expense of utilizing larger memory for prediction.
+        models : list of str or str, default = 'best'
+            Model names of models to compile.
+            If 'best' then the model with the highest validation score is compiled (this is the model used for prediction by default).
+            If 'all' then all models are compiled.
+            Valid models are listed in this `predictor` by calling `predictor.get_model_names()`.
+        with_ancestors : bool, default = True
+            If True, all ancestor models of the provided models will also be compiled.
+        compiler_configs : dict or str, default = "auto"
+            If "auto", defaults to the following:
+                compiler_configs = {
+                    "RF": {"compiler": "onnx"},
+                    "XT": {"compiler": "onnx"},
+                }
+            Otherwise, specify a compiler_configs dictionary manually. Keys can be exact model names or model types.
+            Exact model names take priority over types if both are valid for a model.
+            Types can be either the true type such as RandomForestModel or the shorthand "RF".
+            The dictionary key logic for types is identical to the logic in the hyperparameters argument of `predictor.fit`
+
+            Example values within the configs:
+                compiler : str, default = None
+                    The compiler that is used for model compilation.
+                batch_size : int, default = None
+                    The batch size that is optimized for model prediction.
+                    By default, the batch size is None. This means the compiler would try to leverage dynamic shape for prediction.
+                    Using batch_size=1 would be more suitable for online prediction, which expects a result from one data point.
+                    However, it can be slow for batch processing, because of the overhead of multiple kernel execution.
+                    Increasing batch size to a number that is larger than 1 would help increase the prediction throughput.
+                    This comes with an expense of utilizing larger memory for prediction.
         """
         self._assert_is_fit('compile_models')
+        if isinstance(compiler_configs, str):
+            if compiler_configs == 'auto':
+                compiler_configs = {
+                    "RF": {"compiler": "onnx"},
+                    "XT": {"compiler": "onnx"},
+                }
+            else:
+                raise ValueError(f'Unknown compiler_configs preset: "{compiler_configs}"')
         self._trainer.compile_models(model_names=models, with_ancestors=with_ancestors, compiler_configs=compiler_configs)
 
     def persist_models(self, models='best', with_ancestors=True, max_memory=0.1) -> list:

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -1,9 +1,11 @@
 import logging
+from typing import Dict, List
 
+from autogluon.core.models import AbstractModel
 from autogluon.core.trainer.abstract_trainer import AbstractTrainer
 from autogluon.core.utils import generate_train_test_split
 
-from .model_presets.presets import get_preset_models
+from .model_presets.presets import get_preset_models, MODEL_TYPES
 from .model_presets.presets_distill import get_preset_models_distillation
 from ..models.lgb.lgb_model import LGBModel
 
@@ -118,3 +120,19 @@ class AutoTrainer(AbstractTrainer):
 
     def _get_default_proxy_model_class(self):
         return LGBModel
+
+    def compile_models(self, model_names='all', with_ancestors=False, compiler_configs: dict = None) -> List[str]:
+        """Ensures that compiler_configs maps to the correct models if the user specified the same keys as in hyperparameters such as RT, XT, etc."""
+        if compiler_configs is not None:
+            model_types_map = self._get_model_types_map()
+            compiler_configs_new = dict()
+            for k in compiler_configs:
+                if k in model_types_map:
+                    compiler_configs_new[model_types_map[k]] = compiler_configs[k]
+                else:
+                    compiler_configs_new[k] = compiler_configs[k]
+            compiler_configs = compiler_configs_new
+        return super().compile_models(model_names=model_names, with_ancestors=with_ancestors, compiler_configs=compiler_configs)
+
+    def _get_model_types_map(self) -> Dict[str, AbstractModel]:
+        return MODEL_TYPES

--- a/tabular/tests/unittests/models/test_rf.py
+++ b/tabular/tests/unittests/models/test_rf.py
@@ -55,3 +55,29 @@ def test_rf_regression_compile_onnx(fit_helper):
     compiler_configs = {RFModel: {'compiler': 'onnx'}}
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
                                         compile_models=True, compiler_configs=compiler_configs)
+
+
+def test_rf_binary_compile_onnx_no_config_bagging(fit_helper):
+    # FIXME: The below code will crash because:
+    #  1. We train with a bag, specifically RandomForest that has efficient OOB and thus only trains 1 fold model
+    #  2. We compile RandomForest bag to onnx
+    #  3. We call refit_full, performing efficient cloning when fitting refit_full for RandomForest, avoiding fitting again
+    #  4. The save of the fold 1 model of RandomForest_BAG_L1 into new location in RandomForest_BAG_L1_FULL does not carry over the model.onnx file
+    #  5. Crashes when trying to load the model.onnx file because it doesn't exist.
+    # FIXME: This bug only appears if the user calls refit_full on compiled models.
+    # Solution: Either,
+    #  1. force copy the entire directory of the fold 1 model when cloning instead of calling model.save() -> reuse logic in predictor.clone()
+    #  2. model._compiler stores context of files it has created / depends on, and then detects if saving to a new location,
+    #     then copies the files to that location or computes them again.
+    run_test = False
+    if run_test:
+        fit_args = dict(
+            hyperparameters={RFModel: {}},
+            num_bag_folds=2,
+        )
+        dataset_name = 'adult'
+        compiler_configs = "auto"
+        fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args,
+                                            compile_models=True, compiler_configs=compiler_configs)
+
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/pull/2260

*Description of changes:*
Refactored logic to fix bugs and streamline user experience
- Fixed bug where calling compile twice would either crash or compile the model again, instead skips if already compiled
- Fixed bug where calling `predictor.compile_models()` would crash due to default None for compiler_configs
- Fixed bug where bagging/stacking models would not compile
- Added logging for compile_models logic
- Allow user to specify types via `'RF'` in compiler_configs.
- Switched priority of compiler_config keys so that explicit model names have top priority.
- Removed redundant model save calls in model.compile()
- Refactored native RF compiler to save_in_pkl correctly, now once compiled to onnx takes 1/3rd disk space than before
- Moved `_compiler` save and load logic from RandomForestModel to AbstractModel to simplify future model additions and avoid code duplication.
- Added documentation
- Added skipping of models in compile_models if a config is not specified for them
- Added default "auto" compiler_configs to improve usability
- Added self.save() call in AbstractTrainer.compile_models to avoid losing compile_time information.
- Added advanced unit test showcasing a bug that remains in the current implementation. This can be planned to be fixed in a separate follow-up PR.

Output example of new logging:

```
predictor.compile_models()
```

```
Compiling 3 Models ...
Skipping compilation for WeightedEnsemble_L2 ... (No config specified)
Skipping compilation for CatBoost_BAG_L1 ... (No config specified)
Compiling model: RandomForest_BAG_L1 ... Config = {'compiler': 'onnx'}
	Compiled model with "onnx" backend ...
	2.98s	 = Compile    runtime
Finished compiling models, total runtime = 2.98s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
