### PR TITLE
[multimodal] change default inference strategy from dp to ddp

### DIFF
--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -32,7 +32,7 @@ def compute_num_gpus(config_num_gpus: Union[int, float, List], strategy: str):
     config_num_gpus
         The gpu number provided by config.
     strategy
-        A lightning trainer's strategy such as "ddp", "ddp_spawn", and "dp".
+        A lightning trainer's strategy such as "ddp" and "ddp_spawn".
 
     Returns
     -------
@@ -194,8 +194,8 @@ def compute_inference_batch_size(
     else:
         batch_size = per_gpu_batch_size * eval_batch_size_ratio
 
-    if num_gpus > 1 and strategy == "dp":
-        # If using 'dp', the per_gpu_batch_size would be split by all GPUs.
+    if num_gpus > 1 and strategy == "ddp":
+        # If using 'ddp', the per_gpu_batch_size would be split by all GPUs.
         # So, we need to use the GPU number as a multiplier to compute the batch size.
         batch_size = batch_size * num_gpus
 

--- a/multimodal/src/autogluon/multimodal/utils/export.py
+++ b/multimodal/src/autogluon/multimodal/utils/export.py
@@ -256,7 +256,7 @@ class ExportMixin:
         # Perform tracing on cpu
         device_type = "cpu"
         num_gpus = 0
-        strategy = "dp"  # default used in inference.
+        strategy = "ddp"  # default used in inference.
         device = torch.device(device_type)
         dtype = infer_precision(
             num_gpus=num_gpus, precision=self._config.env.precision, cpu_only_warning=False, as_torch=True

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -475,7 +475,7 @@ def predict(
             requires_label=requires_label,
         )
 
-    strategy = "dp"  # default used in inference.
+    strategy = "ddp"  # default used in inference.
 
     num_gpus = compute_num_gpus(config_num_gpus=predictor._config.env.num_gpus, strategy=strategy)
 


### PR DESCRIPTION
*Issue #, if available:*

DP strategy has been dropped in latest version of PyTorch Lightning: https://lightning.ai/docs/pytorch/stable/extensions/strategy.html#selecting-a-built-in-strategy

*Description of changes:*

1. change default inference strategy from dp to ddp

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
